### PR TITLE
Refactor Kobalt's API clients to use refit

### DIFF
--- a/src/InfractionsAPI/Kobalt.Infractions.API/Services/IInfractionService.cs
+++ b/src/InfractionsAPI/Kobalt.Infractions.API/Services/IInfractionService.cs
@@ -1,10 +1,9 @@
-﻿using Kobalt.Infractions.Shared.DTOs;
-using Kobalt.Infractions.Shared.Payloads;
-using Refit;
+﻿using Kobalt.Infractions.Shared;
+using Kobalt.Infractions.Shared.DTOs;
 using Remora.Rest.Core;
 using Remora.Results;
 
-namespace Kobalt.Infractions.Shared.Interfaces;
+namespace Kobalt.Infractions.API.Services;
 
 public interface IInfractionService
 {
@@ -56,37 +55,4 @@ public interface IInfractionService
     /// <returns>All additionally-generated infractions, if any.</returns>
     Task<Optional<IReadOnlyList<InfractionDTO>>> EvaluateInfractionsAsync(ulong guildID, ulong userID);
 
-}
-
-public interface IInfractionAPI
-{
-    [Put("/infractions/guilds/{guildID}")]
-    public Task<InfractionResponsePayload> CreateInfractionAsync(Snowflake guildID, [Body] InfractionCreatePayload payload);
-
-    [Get("/infractions/guilds/{guildID}")]
-    public Task<IReadOnlyList<InfractionDTO>> GetGuildInfractionsAsync(Snowflake guildID, int? page = 1, int? pageSize = 10);
-
-    [Get("/infractions/guilds/{guildID}/{id}")]
-    public Task<InfractionDTO> GetGuildInfractionAsync(Snowflake guildID, int id);
-
-    [Patch("/infractions/guilds/{guildID}/{id}")]
-    public Task<InfractionDTO> UpdateInfractionAsync(Snowflake guildID, int id, [Body] InfractionUpdatePayload payload);
-
-    [Get("/infractions/guilds/{guildID}/users/{id}")]
-    public Task<IReadOnlyList<InfractionDTO>> GetInfractionsForUserAsync(Snowflake guildID, Snowflake id, [Query] [AliasAs("with_pardons")] bool withPardons = false);
-
-    [Get("/infractions/{guildID}/rules")]
-    public Task<IReadOnlyList<InfractionRuleDTO>> GetInfractionRulesAsync(Snowflake guildID);
-
-    [Post("/infractions/{guildID}/rules")]
-    public Task<InfractionRuleDTO> CreateInfractionRuleAsync(Snowflake guildID, [Body] InfractionRuleDTO rule);
-
-    [Patch("/infractions/{guildID}/rules/{id}")]
-    public Task<InfractionRuleDTO> UpdateInfractionRuleAsync(Snowflake guildID, int id, [Body] InfractionRuleDTO rule);
-
-    [Delete("/infractions/{guildID}/rules/{id}")]
-    public Task DeleteInfractionRuleAsync(Snowflake guildID, int id);
-
-    [Get("/infractions/{guildID}/rules/{id}")]
-    public Task<InfractionRuleDTO> GetInfractionRuleAsync(Snowflake guildID, int id);
 }

--- a/src/InfractionsAPI/Kobalt.Infractions.Shared/Interfaces/IInfractionAPI.cs
+++ b/src/InfractionsAPI/Kobalt.Infractions.Shared/Interfaces/IInfractionAPI.cs
@@ -1,0 +1,39 @@
+using Kobalt.Infractions.Shared.DTOs;
+using Kobalt.Infractions.Shared.Payloads;
+using Refit;
+using Remora.Rest.Core;
+
+namespace Kobalt.Infractions.Shared.Interfaces;
+
+public interface IInfractionAPI
+{
+    [Put("/infractions/guilds/{guildID}")]
+    public Task<InfractionResponsePayload> CreateInfractionAsync(Snowflake guildID, [Body] InfractionCreatePayload payload);
+
+    [Get("/infractions/guilds/{guildID}")]
+    public Task<IReadOnlyList<InfractionDTO>> GetGuildInfractionsAsync(Snowflake guildID, int? page = 1, int? pageSize = 10);
+
+    [Get("/infractions/guilds/{guildID}/{id}")]
+    public Task<InfractionDTO> GetGuildInfractionAsync(Snowflake guildID, int id);
+
+    [Patch("/infractions/guilds/{guildID}/{id}")]
+    public Task<InfractionDTO> UpdateInfractionAsync(Snowflake guildID, int id, [Body] InfractionUpdatePayload payload);
+
+    [Get("/infractions/guilds/{guildID}/users/{id}")]
+    public Task<IReadOnlyList<InfractionDTO>> GetInfractionsForUserAsync(Snowflake guildID, Snowflake id, [Query] [AliasAs("with_pardons")] bool withPardons = false);
+
+    [Get("/infractions/{guildID}/rules")]
+    public Task<IReadOnlyList<InfractionRuleDTO>> GetInfractionRulesAsync(Snowflake guildID);
+
+    [Post("/infractions/{guildID}/rules")]
+    public Task<InfractionRuleDTO> CreateInfractionRuleAsync(Snowflake guildID, [Body] InfractionRuleDTO rule);
+
+    [Patch("/infractions/{guildID}/rules/{id}")]
+    public Task<InfractionRuleDTO> UpdateInfractionRuleAsync(Snowflake guildID, int id, [Body] InfractionRuleDTO rule);
+
+    [Delete("/infractions/{guildID}/rules/{id}")]
+    public Task DeleteInfractionRuleAsync(Snowflake guildID, int id);
+
+    [Get("/infractions/{guildID}/rules/{id}")]
+    public Task<InfractionRuleDTO> GetInfractionRuleAsync(Snowflake guildID, int id);
+}

--- a/src/InfractionsAPI/Kobalt.Infractions.Shared/Interfaces/IInfractionService.cs
+++ b/src/InfractionsAPI/Kobalt.Infractions.Shared/Interfaces/IInfractionService.cs
@@ -1,4 +1,6 @@
 ﻿using Kobalt.Infractions.Shared.DTOs;
+using Kobalt.Infractions.Shared.Payloads;
+using Refit;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -54,4 +56,37 @@ public interface IInfractionService
     /// <returns>All additionally-generated infractions, if any.</returns>
     Task<Optional<IReadOnlyList<InfractionDTO>>> EvaluateInfractionsAsync(ulong guildID, ulong userID);
 
+}
+
+public interface IInfractionAPI
+{
+    [Put("/infractions/guilds/{guildID}")]
+    public Task<InfractionResponsePayload> CreateInfractionAsync(Snowflake guildID, [Body] InfractionCreatePayload payload);
+
+    [Get("/infractions/guilds/{guildID}")]
+    public Task<IReadOnlyList<InfractionDTO>> GetGuildInfractionsAsync(Snowflake guildID, int? page = 1, int? pageSize = 10);
+
+    [Get("/infractions/guilds/{guildID}/{id}")]
+    public Task<InfractionDTO> GetGuildInfractionAsync(Snowflake guildID, int id);
+
+    [Patch("/infractions/guilds/{guildID}/{id}")]
+    public Task<InfractionDTO> UpdateInfractionAsync(Snowflake guildID, int id, [Body] InfractionUpdatePayload payload);
+
+    [Get("/infractions/guilds/{guildID}/users/{id}")]
+    public Task<IReadOnlyList<InfractionDTO>> GetInfractionsForUserAsync(Snowflake guildID, Snowflake id, [Query] [AliasAs("with_pardons")] bool withPardons = false);
+
+    [Get("/infractions/{guildID}/rules")]
+    public Task<IReadOnlyList<InfractionRuleDTO>> GetInfractionRulesAsync(Snowflake guildID);
+
+    [Post("/infractions/{guildID}/rules")]
+    public Task<InfractionRuleDTO> CreateInfractionRuleAsync(Snowflake guildID, [Body] InfractionRuleDTO rule);
+
+    [Patch("/infractions/{guildID}/rules/{id}")]
+    public Task<InfractionRuleDTO> UpdateInfractionRuleAsync(Snowflake guildID, int id, [Body] InfractionRuleDTO rule);
+
+    [Delete("/infractions/{guildID}/rules/{id}")]
+    public Task DeleteInfractionRuleAsync(Snowflake guildID, int id);
+
+    [Get("/infractions/{guildID}/rules/{id}")]
+    public Task<InfractionRuleDTO> GetInfractionRuleAsync(Snowflake guildID, int id);
 }

--- a/src/InfractionsAPI/Kobalt.Infractions.Shared/Kobalt.Infractions.Shared.csproj
+++ b/src/InfractionsAPI/Kobalt.Infractions.Shared/Kobalt.Infractions.Shared.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Refit" Version="7.1.2" />
       <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
       <PackageReference Include="Remora.Results" Version="7.4.1" />
     </ItemGroup>

--- a/src/Kobalt/Kobalt.Bot.Data/Entities/RoleMenus/RoleMenuOptionEntity.cs
+++ b/src/Kobalt/Kobalt.Bot.Data/Entities/RoleMenus/RoleMenuOptionEntity.cs
@@ -31,7 +31,7 @@ public class RoleMenuOptionConfiguration : IEntityTypeConfiguration<RoleMenuOpti
     public void Configure(EntityTypeBuilder<RoleMenuOptionEntity> builder)
     {
         builder.ToTable("role_menu_options");
- 
+
         // TODO: Update to EF Core 8, where primitive collections are supported natively (translated to JSONB)
         builder
         .Property(rmo => rmo.MutuallyInclusiveRoles)
@@ -40,7 +40,7 @@ public class RoleMenuOptionConfiguration : IEntityTypeConfiguration<RoleMenuOpti
             roles => string.Join(',', roles),
             str => str.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => new Snowflake(ulong.Parse(s), 0)).ToList()
         );
-        
+
         builder
         .Property(rmo => rmo.MutuallyExclusiveRoles)
         .HasConversion<string>
@@ -49,4 +49,4 @@ public class RoleMenuOptionConfiguration : IEntityTypeConfiguration<RoleMenuOpti
             str => str.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => new Snowflake(ulong.Parse(s), 0)).ToList()
         );
     }
-} 
+}

--- a/src/Kobalt/Kobalt.Bot/Autocomplete/ReminderAutoCompleteProvider.cs
+++ b/src/Kobalt/Kobalt.Bot/Autocomplete/ReminderAutoCompleteProvider.cs
@@ -42,19 +42,19 @@ public class ReminderAutoCompleteProvider : IAutocompleteProvider
             return Array.Empty<IApplicationCommandOptionChoice>();
         }
 
-        if (!_cache.TryGetValue($"{userId}_reminders", out ReminderDTO[]? reminders))
+        if (!_cache.TryGetValue($"{userId}_reminders", out IReadOnlyList<ReminderDTO>? reminders))
         {
             var reminderResult = await _reminders.GetRemindersAsync(userId);
-            
+
             if (!reminderResult.IsSuccess)
             {
                 return Array.Empty<IApplicationCommandOptionChoice>();
             }
-            
+
             reminders = reminderResult.Entity;
             _cache.Set($"{userId}_reminders", reminders, TimeSpan.FromMinutes(5));
         }
-        
+
         var now = DateTimeOffset.UtcNow;
 
         var suggestions = reminders!
@@ -70,7 +70,7 @@ public class ReminderAutoCompleteProvider : IAutocompleteProvider
                           )
                           .Select(s => new ApplicationCommandOptionChoice(s.Item2, s.Id.ToString()))
                           .ToArray();
-        
+
         return suggestions;
     }
 }

--- a/src/Kobalt/Kobalt.Bot/Kobalt.Bot.csproj
+++ b/src/Kobalt/Kobalt.Bot/Kobalt.Bot.csproj
@@ -13,6 +13,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Refit" Version="7.1.2" />
+      <PackageReference Include="Refit.HttpClientFactory" Version="7.1.2" />
       <PackageReference Include="Remora.Discord.Caching" Version="39.0.0" />
       <PackageReference Include="Remora.Discord.Caching.Redis" Version="1.1.8" />
       <PackageReference Include="Remora.Discord.Commands" Version="28.1.0" />

--- a/src/Kobalt/Kobalt.Shared/Kobalt.Shared.csproj
+++ b/src/Kobalt/Kobalt.Shared/Kobalt.Shared.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="NodaTime" Version="3.1.10" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
       <PackageReference Include="Recognizers.Text.DateTime.Wrapper" Version="1.0.5" />
+      <PackageReference Include="Refit" Version="7.1.2" />
       <PackageReference Include="Remora.Discord.API" Version="78.0.0" />
       <PackageReference Include="Remora.Discord.Pagination" Version="4.0.0" />
       <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />

--- a/src/Kobalt/Kobalt.Shared/Services/IKobaltRestRemindersAPI.cs
+++ b/src/Kobalt/Kobalt.Shared/Services/IKobaltRestRemindersAPI.cs
@@ -1,0 +1,36 @@
+using Kobalt.Shared.DTOs.Reminders;
+using Refit;
+using Remora.Rest.Core;
+
+namespace Kobalt.Shared.Services;
+
+/// <summary>
+/// Represents a REST API for interacting with Kobalt's Reminder API.
+/// </summary>
+public interface IKobaltRestRemindersAPI
+{
+    /// <summary>
+    /// Creates a new reminder.
+    /// </summary>
+    /// <param name="userID">The ID of the user to create a reminder for.</param>
+    /// <param name="payload">The data of the reminder.</param>
+    /// <returns>The created reminder.</returns>
+    [Post("/api/reminders/{userID}")]
+    public Task<ReminderCreationPayload> CreateReminderAsync(Snowflake userID, [Body] ReminderCreatePayload payload);
+
+    /// <summary>
+    /// Gets all reminders for a user.
+    /// </summary>
+    /// <param name="userID">The ID of the user to get reminders for.</param>
+    /// <returns>The user's reminders.</returns>
+    [Get("/api/reminders/{userID}")]
+    public Task<IReadOnlyList<ReminderDTO>> GetRemindersAsync(Snowflake userID);
+
+    /// <summary>
+    /// Deletes a reminder.
+    /// </summary>
+    /// <param name="userID">The ID of the user deleting a reminder.</param>
+    /// <param name="ids">The IDs of the reminder being deleted.</param>
+    [Delete("/api/reminders/{userID}")]
+    public Task DeleteRemindersAsync(Snowflake userID, IReadOnlyList<int> ids);
+}

--- a/src/PhishingAPI/Kobalt.Phishing.Shared/Interfaces/IKobaltRestPhishingAPI.cs
+++ b/src/PhishingAPI/Kobalt.Phishing.Shared/Interfaces/IKobaltRestPhishingAPI.cs
@@ -1,0 +1,45 @@
+using Kobalt.Phishing.Shared.Models;
+using Refit;
+using Remora.Rest.Core;
+
+namespace Kobalt.Phishing.Shared.Interfaces;
+
+/// <summary>
+/// Represents a REST API for interacting with Kobalt's Phishing API.
+/// </summary>
+public interface IKobaltRestPhishingAPI
+{
+    /// <summary>
+    /// Checks if a user is suspicious.
+    /// </summary>
+    /// <param name="guildID">The ID of the guild to check for.</param>
+    /// <param name="user">The request body.</param>
+    /// <returns>A result determining whether the user is suspicious.</returns>
+    [Post("/phishing/check/{guildID}/user")]
+    public Task<UserPhishingDetectionResult> CheckUserAsync(Snowflake guildID, [Body] CheckUserRequest user);
+
+    /// <summary>
+    /// Checks if a domain is suspicious.
+    /// </summary>
+    /// <param name="domains">The domains to check.</param>
+    /// <returns>A list of domains that are suspicious.</returns>
+    [Post("/phishing/check/domains")]
+    public Task<UserPhishingDetectionResult> CheckLinksAsync([Body] IReadOnlyList<string> domains);
+
+    /// <summary>
+    /// Creates a new record for a suspicious username on a guild.
+    /// </summary>
+    /// <param name="guildID">The ID of the guild to create a record for.</param>
+    /// <param name="request">The data of the request.</param>
+    [Put("/phishing/{guildID}/username")]
+    public Task CreateSuspiciousUsernameAsync(Snowflake guildID, [Body] SubmitUsernameRequest request);
+
+    /// <summary>
+    /// Creates a new record for a suspicious avatar on a guild.
+    /// </summary>
+    /// <param name="guildID">The ID of the guild to create a record for.</param>
+    /// <param name="request">The data of the request.</param>
+    [Put("/phishing/{guildID}/avatar")]
+    public Task CreateSuspiciousUserAvatarAsync(Snowflake guildID, [Body] SubmitAvatarRequest request);
+
+}

--- a/src/PhishingAPI/Kobalt.Phishing.Shared/Kobalt.Phishing.Shared.csproj
+++ b/src/PhishingAPI/Kobalt.Phishing.Shared/Kobalt.Phishing.Shared.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Refit" Version="7.1.2" />
       <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR refactors Kobalt's orthoganal APIs (reminders, phishing, and infractions) to use API interfaces generated by [refit](https://github.com/reactiveui/refit) - the implementations also use Polly policies, so all APIs will retry (as opposed to doing it manually in just one of the APIs prior).