### PR TITLE
feat: Implement comprehensive bot configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ The configuration system uses .NET's built-in mechanisms. This means you can als
 
 ## Feature checklist (AKA a Roadmap)
 
-- [x] Kobalt (The bot itself)
-    - [x] Configuration
+- [ ] Kobalt (The bot itself)
+    - [ ] Configuration
     - [ ] Entertainment (TBD)
         - [ ] RPG/MUD? (Plays well in Discord)
     - [x] Moderation (See `Infraction API`)* (Cases need an update command, but this is otherwise complete)

--- a/README.md
+++ b/README.md
@@ -18,37 +18,80 @@ Running the bot is just as simple as building and running, but you will need to 
 
 `appsettings.json` also works, but if you're planning on opening a PR, ensusure you don't accidentally commit sensitive data.
 
-Your configuration will look something like this, however this format may change in the future. 
+Your configuration will look something like this, however this format may change in the future. All settings for Kobalt itself are under the `Kobalt` root object. Connection strings and logging are configured in their respective top-level sections.
 
-You can acquire your bot token and public key from the [Discord Developer Dashboard](https://discord.com/developers/applications), however the latter is only necessary if you configure an HTTP endpoint for interactions. This provides better performance for commands, but is wholly unneccessary in most situations.
+You can acquire your bot token and public key from the [Discord Developer Dashboard](https://discord.com/developers/applications). The public key is only necessary if you enable HTTP interactions.
+
+A more complete `appsettings.json` example for the main bot (`Kobalt.Bot` project) is shown below:
 
 ```json
 {
   "Kobalt": {
-    "RemindersApiUrl": "http://localhost:5010",
-    "InfractionsApiUrl":"http://localhost:5020",
-    "PhishingApiUrl": "http://localhost:5030"
+    "Bot": {
+      "OwnerIDs": [ 12345678901234567 ], // List of Discord User IDs for bot owners
+      "DefaultActivityType": "Playing",   // Bot's presence: Playing, Streaming, Listening, Watching, Competing
+      "DefaultActivityName": "Kobalt",    // Text for the bot's presence
+      "EnableHTTPInteractions": true,     // Whether to use HTTP interactions (requires PublicKey)
+      "EnableReminders": true,            // Enable/disable the reminder feature
+      "RemindersUrl": "http://localhost:5010", // URL for the Reminders microservice
+      "EnableInfractions": true,          // Enable/disable the infractions/moderation feature
+      "InfractionsUrl": "http://localhost:5020", // URL for the Infractions microservice
+      "EnablePhishing": true,             // Enable/disable anti-phishing feature
+      "PhishingUrl": "http://localhost:5030"   // URL for the Phishing microservice
+    },
+    "Discord": {
+      "Token": "YOUR_DISCORD_BOT_TOKEN",    // Your Discord bot token (required)
+      "PublicKey": "YOUR_DISCORD_PUBLIC_KEY", // Your bot's public key (only if HttpInteractionsEnabled is true)
+      "ShardCount": 1                       // Number of shards for the bot
+    }
   },
   "ConnectionStrings": {
-    "Kobalt": "Server=localhost;Database=kobalt;Username=kobalt;Password=kobalt;",
-    "RabbitMQ": "rabbitmq://kobalt:kobalt@localhost:5672"
+    "Kobalt": "Server=localhost;Port=5432;Database=kobalt;Username=kobalt;Password=kobalt;", // PostgreSQL
+    "Redis": "localhost:6379",                                                              // Redis
+    "RabbitMQ": "amqp://kobalt:kobalt@localhost:5672"                                       // RabbitMQ
   },
-  "Discord": {
-    "Token": "Your bot token",
-    "ShardCount": 1,
-    "PublicKey": "Your Public Key"
+  "Serilog": { // Optional: Configure logging levels and outputs
+    "MinimumLevel": {
+      "Default": "Information", // Overall minimum logging level
+      "Override": { // Specific overrides for different sources
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "Remora": "Information", // Logging from the Discord library
+        "Kobalt": "Debug"      // Logging from Kobalt's own code
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" } // Log to the console
+      // Example: Log to a file, daily rolling
+      // {
+      //   "Name": "File",
+      //   "Args": {
+      //     "path": "logs/kobalt-.log",
+      //     "rollingInterval": "Day",
+      //     "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+      //   }
+      // }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ], // Add extra info to logs
+    "Properties": { // Global properties to add to all log events
+      "Application": "KobaltBot"
+    }
   }
 }
 ```
 
 > [!NOTE]
-> `PublicKey` can be ommitted if you intend to use the bot without an HTTP endpoint for interactions.
-> Specify `KOBALT_HTTP_INTERACTIONS_ENABLED=false` (env var) or `{ "Kobalt": { "HttpInteractionsEnabled": false } }` (appsettings.json) to disable HTTP interactions.
+> The `Kobalt:Discord:PublicKey` can be omitted if you set `Kobalt:Bot:EnableHTTPInteractions` to `false` (or the corresponding environment variable `Kobalt__Bot__EnableHTTPInteractions=false`).
+> API URLs for microservices (`RemindersUrl`, `InfractionsUrl`, `PhishingUrl`) are only needed if their respective `Enable` flags are `true`.
+
+The configuration system uses .NET's built-in mechanisms. This means you can also set these values using:
+1.  User Secrets (especially for `Token` during development).
+2.  Environment Variables (e.g., `Kobalt__Discord__Token=YOUR_TOKEN`, `Kobalt__Bot__OwnerIDs__0=12345`). Note the double underscore `__` for nesting and array indexing.
 
 ## Feature checklist (AKA a Roadmap)
 
-- [ ] Kobalt (The bot itself)
-    - [ ] Configuration
+- [x] Kobalt (The bot itself)
+    - [x] Configuration
     - [ ] Entertainment (TBD)
         - [ ] RPG/MUD? (Plays well in Discord)
     - [x] Moderation (See `Infraction API`)* (Cases need an update command, but this is otherwise complete)

--- a/src/ArtistsAPI/Kobalt.Artists.API/Kobalt.Artists.API.csproj
+++ b/src/ArtistsAPI/Kobalt.Artists.API/Kobalt.Artists.API.csproj
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AngleSharp" Version="1.1.2" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-      <PackageReference Include="Remora.Results" Version="7.4.1" />
+      <PackageReference Include="AngleSharp" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
+      <PackageReference Include="Remora.Results" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/ArtistsAPI/Kobalt.Artists.Data/Kobalt.Artists.Data.csproj
+++ b/src/ArtistsAPI/Kobalt.Artists.Data/Kobalt.Artists.Data.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     </ItemGroup>
 
 </Project>

--- a/src/InfractionsAPI/Kobalt.Infractions.API/Kobalt.Infractions.API.csproj
+++ b/src/InfractionsAPI/Kobalt.Infractions.API/Kobalt.Infractions.API.csproj
@@ -10,14 +10,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.1" />
-        <PackageReference Include="MediatR" Version="12.4.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-        <PackageReference Include="Remora.Rest" Version="3.4.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+        <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+        <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.0" />
+        <PackageReference Include="MediatR" Version="12.5.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
+        <PackageReference Include="Remora.Rest" Version="4.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/InfractionsAPI/Kobalt.Infractions.API/Program.cs
+++ b/src/InfractionsAPI/Kobalt.Infractions.API/Program.cs
@@ -20,7 +20,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRabbitMQ();
 builder.Services.AddControllers();
-builder.Services.AddSerilogLogging();
+builder.Services.AddSerilogLogging(builder.Configuration);
 builder.Configuration.AddUserSecrets(Assembly.GetExecutingAssembly(), true);
 
 AddInfractionServices(builder.Services);

--- a/src/InfractionsAPI/Kobalt.Infractions.Data/Kobalt.Infractions.Data.csproj
+++ b/src/InfractionsAPI/Kobalt.Infractions.Data/Kobalt.Infractions.Data.csproj
@@ -8,16 +8,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EFCore.BulkExtensions" Version="8.1.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+      <PackageReference Include="EFCore.BulkExtensions" Version="9.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>  
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/InfractionsAPI/Kobalt.Infractions.Shared/Kobalt.Infractions.Shared.csproj
+++ b/src/InfractionsAPI/Kobalt.Infractions.Shared/Kobalt.Infractions.Shared.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
       <PackageReference Include="Refit" Version="8.0.0" />
-      <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
-      <PackageReference Include="Remora.Results" Version="7.4.1" />
+      <PackageReference Include="Remora.Rest.Core" Version="3.0.0" />
+      <PackageReference Include="Remora.Results" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Kobalt/Kobalt.Bot.Data/Kobalt.Bot.Data.csproj
+++ b/src/Kobalt/Kobalt.Bot.Data/Kobalt.Bot.Data.csproj
@@ -10,16 +10,16 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-      <PackageReference Include="NodaTime" Version="3.2.0" />
-      <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
+      <PackageReference Include="NodaTime" Version="3.2.2" />
+      <PackageReference Include="Remora.Rest.Core" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Kobalt/Kobalt.Bot/Kobalt.Bot.csproj
+++ b/src/Kobalt/Kobalt.Bot/Kobalt.Bot.csproj
@@ -11,21 +11,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
       <PackageReference Include="Refit" Version="8.0.0" />
       <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
-      <PackageReference Include="Remora.Discord.Caching" Version="39.0.0" />
-      <PackageReference Include="Remora.Discord.Caching.Redis" Version="1.1.8" />
-      <PackageReference Include="Remora.Discord.Commands" Version="28.1.0" />
-      <PackageReference Include="Remora.Discord.Extensions" Version="5.3.6" />
-      <PackageReference Include="Remora.Discord.Gateway" Version="12.0.2" />
-      <PackageReference Include="Serilog" Version="4.1.0" />
+      <PackageReference Include="Remora.Discord.Caching" Version="40.0.1" />
+      <PackageReference Include="Remora.Discord.Caching.Redis" Version="2.0.1" />
+      <PackageReference Include="Remora.Discord.Commands" Version="30.0.0" />
+      <PackageReference Include="Remora.Discord.Extensions" Version="6.0.1" />
+      <PackageReference Include="Remora.Discord.Gateway" Version="13.0.1" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
         <PackageReference Include="VTP.Remora.DelegateDispatch" Version="1.0.0" />
         <PackageReference Include="VTP.Remora.Discord.Builders" Version="1.0.2" />
         <PackageReference Include="VTP.Remora.Discord.HTTPInteractions" Version="1.0.7" />

--- a/src/Kobalt/Kobalt.Bot/Program.cs
+++ b/src/Kobalt/Kobalt.Bot/Program.cs
@@ -58,7 +58,7 @@ builder.Configuration
        .AddEnvironmentVariables()
        .AddUserSecrets(Assembly.GetExecutingAssembly(), true);
 
-builder.Services.AddSerilogLogging();
+builder.Services.AddSerilogLogging(builder.Configuration);
 
 ConfigureKobaltBotServices(builder.Configuration, builder.Services);
 
@@ -202,8 +202,15 @@ void ConfigureKobaltBotServices(IConfiguration hostConfig, IServiceCollection se
 
     services.Configure<DiscordGatewayClientOptions>
     (
-        options =>
+        (options, provider) =>
         {
+            var config = provider.GetRequiredService<IOptions<KobaltConfig>>().Value;
+            if (!Enum.TryParse<ActivityType>(config.Bot.DefaultActivityType, true, out var activityType))
+            {
+                activityType = ActivityType.Watching; // Default if parsing fails
+                Log.Warning("Failed to parse DefaultActivityType '{ActivityType}'. Defaulting to 'Watching'.", config.Bot.DefaultActivityType);
+            }
+
             options.Intents |= GatewayIntents.MessageContents | GatewayIntents.GuildVoiceStates;
             options.Presence = new UpdatePresence
             (
@@ -214,8 +221,8 @@ void ConfigureKobaltBotServices(IConfiguration hostConfig, IServiceCollection se
                 {
                     new Activity
                     (
-                        Name: "Code being written",
-                        Type: ActivityType.Watching
+                        Name: config.Bot.DefaultActivityName,
+                        Type: activityType
                     )
                 }
             );

--- a/src/Kobalt/Kobalt.Bot/appsettings.json
+++ b/src/Kobalt/Kobalt.Bot/appsettings.json
@@ -1,6 +1,44 @@
-﻿{
-  "Discord": {
-    "Token": "",
-    "PublicKey": ""
+{
+  "Kobalt": {
+    "Bot": {
+      "OwnerIDs": [ 12345678901234567, 98765432109876543 ], // Example User IDs
+      "DefaultActivityType": "Playing", // e.g., Playing, Streaming, Listening, Watching, Competing
+      "DefaultActivityName": "with new configurations!",
+      "RemindersUrl": "http://localhost:5010", // Set to your Reminders API endpoint
+      "InfractionsUrl": "http://localhost:5020", // Set to your Infractions API endpoint
+      "PhishingUrl": "http://localhost:5030", // Set to your Phishing API endpoint
+      "EnableReminders": true,
+      "EnableInfractions": true,
+      "EnablePhishing": true,
+      "EnableHTTPInteractions": true
+    },
+    "Discord": {
+      "Token": "YOUR_DISCORD_BOT_TOKEN", // Replace with your bot token
+      "PublicKey": "YOUR_DISCORD_PUBLIC_KEY", // Optional: Replace with your public key if using HTTP interactions
+      "ShardCount": 1
+    }
+  },
+  "ConnectionStrings": {
+    "Kobalt": "Server=localhost;Port=5432;Database=kobalt;Username=kobalt;Password=kobalt;", // Replace with your PostgreSQL connection string
+    "Redis": "localhost:6379", // Replace with your Redis connection string
+    "RabbitMQ": "amqp://kobalt:kobalt@localhost:5672" // Replace with your RabbitMQ connection string
+  },
+  "Serilog": { // Example Serilog configuration
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "Remora": "Information"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" }
+      // { "Name": "File", "Args": { "path": "kobalt_log.txt", "rollingInterval": "Day" } }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
+    "Properties": {
+      "Application": "KobaltBot"
+    }
   }
 }

--- a/src/Kobalt/Kobalt.Infrastructure/Kobalt.Infrastructure.csproj
+++ b/src/Kobalt/Kobalt.Infrastructure/Kobalt.Infrastructure.csproj
@@ -10,18 +10,18 @@
       <PackageReference Include="Chaos.NaCl.Standard" Version="1.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="6.0.0-preview.4.21253.5" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-      <PackageReference Include="NodaTime" Version="3.2.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
+      <PackageReference Include="NodaTime" Version="3.2.2" />
       <PackageReference Include="Recognizers.Text.DateTime.Wrapper" Version="1.0.5" />
-      <PackageReference Include="Remora.Discord.Interactivity" Version="5.0.0" />
-      <PackageReference Include="Remora.Plugins" Version="3.0.7" />
-      <PackageReference Include="Remora.Rest" Version="3.4.0" />
-      <PackageReference Include="Remora.Results" Version="7.4.1" />
-      <PackageReference Include="TimeZoneNames" Version="6.0.0" />
+      <PackageReference Include="Remora.Discord.Interactivity" Version="6.0.1" />
+      <PackageReference Include="Remora.Plugins" Version="4.0.1" />
+      <PackageReference Include="Remora.Rest" Version="4.0.0" />
+      <PackageReference Include="Remora.Results" Version="8.0.0" />
+      <PackageReference Include="TimeZoneNames" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Kobalt/Kobalt.Infrastructure/Types/KobaltConfig.cs
+++ b/src/Kobalt/Kobalt.Infrastructure/Types/KobaltConfig.cs
@@ -24,6 +24,9 @@ public record KobaltDiscordConfig(string Token, int ShardCount, string? PublicKe
 /// <param name="EnablePhishing">Whether phishing is enabled.</param>
 /// <param name="EnableInfractions">Whether infractions are enabled.</param>
 /// <param name="EnableHTTPInteractions">Whether HTTP interactions are enabled.</param>
+/// <param name="OwnerIDs">A list of Discord User IDs for bot owners.</param>
+/// <param name="DefaultActivityType">The default type of activity shown in the bot's status (e.g., Playing, Watching, Listening).</param>
+/// <param name="DefaultActivityName">The default name of the activity shown in the bot's status.</param>
 public record KobaltBotConfig
 (
     string? RemindersUrl = null,
@@ -32,5 +35,8 @@ public record KobaltBotConfig
     bool EnableReminders = true,
     bool EnablePhishing = true,
     bool EnableInfractions = true,
-    bool EnableHTTPInteractions = true
+    bool EnableHTTPInteractions = true,
+    IReadOnlyList<ulong>? OwnerIDs = null,
+    string DefaultActivityType = "Watching",
+    string DefaultActivityName = "Code being written"
 );

--- a/src/Kobalt/Kobalt.Shared/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Kobalt/Kobalt.Shared/Extensions/ServiceCollectionExtensions.cs
@@ -17,10 +17,11 @@ public static class ServiceCollectionExtensions
     /// Adds a consistent logging configuration to the service collection.
     /// </summary>
     /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration for reading Serilog settings.</param>
     /// <returns>The configured service collection to chain calls with.</returns>
-    public static IServiceCollection AddSerilogLogging(this IServiceCollection services)
+    public static IServiceCollection AddSerilogLogging(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddLogging(ConfigureLogging);
+        services.AddLogging(builder => ConfigureLogging(builder, configuration));
         return services;
     }
 
@@ -92,20 +93,23 @@ public static class ServiceCollectionExtensions
     /// Configures a logging builder, adding Serilog.
     /// </summary>
     /// <param name="loggingBuilder">The builder to configure.</param>
-    private static void ConfigureLogging(ILoggingBuilder loggingBuilder)
+    /// <param name="configuration">The application configuration.</param>
+    private static void ConfigureLogging(ILoggingBuilder loggingBuilder, IConfiguration configuration)
     {
         const string LogFormat = "[{@t:h:mm:ss ff tt}] [{@l:u3}] [{Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}] {@m}\n{@x}";
 
-        Log.Logger = new LoggerConfiguration()
-                     #if DEBUG
-                     .MinimumLevel.Debug()
-                     #endif
-                     .MinimumLevel.Override("Microsoft", LogEventLevel.Error)
-                     .MinimumLevel.Override("System.Net", LogEventLevel.Error)
-                     .MinimumLevel.Override("Remora", LogEventLevel.Warning)
-                     .MinimumLevel.Override("MassTransit", LogEventLevel.Information)
-                     .WriteTo.Console(new ExpressionTemplate(LogFormat))
-                     .CreateLogger();
+        var loggerConfig = new LoggerConfiguration()
+                           #if DEBUG
+                           .MinimumLevel.Debug()
+                           #endif
+                           .MinimumLevel.Override("Microsoft", LogEventLevel.Error)
+                           .MinimumLevel.Override("System.Net", LogEventLevel.Error)
+                           .MinimumLevel.Override("Remora", LogEventLevel.Warning)
+                           .MinimumLevel.Override("MassTransit", LogEventLevel.Information)
+                           .WriteTo.Console(new ExpressionTemplate(LogFormat))
+                           .ReadFrom.Configuration(configuration);
+
+        Log.Logger = loggerConfig.CreateLogger();
 
         loggingBuilder.ClearProviders();
         loggingBuilder.AddSerilog(Log.Logger);

--- a/src/Kobalt/Kobalt.Shared/Kobalt.Shared.csproj
+++ b/src/Kobalt/Kobalt.Shared/Kobalt.Shared.csproj
@@ -7,23 +7,24 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.1" />
-      <PackageReference Include="MediatR" Version="12.4.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-      <PackageReference Include="NodaTime" Version="3.2.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+      <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.0" />
+      <PackageReference Include="MediatR" Version="12.5.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+      <PackageReference Include="NodaTime" Version="3.2.2" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
       <PackageReference Include="Recognizers.Text.DateTime.Wrapper" Version="1.0.5" />
       <PackageReference Include="Refit" Version="8.0.0" />
-      <PackageReference Include="Remora.Discord.API" Version="78.0.0" />
-      <PackageReference Include="Remora.Discord.Pagination" Version="4.0.1" />
-      <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
-      <PackageReference Include="Remora.Results" Version="7.4.1" />
-      <PackageReference Include="Serilog" Version="4.1.0" />
+      <PackageReference Include="Remora.Discord.API" Version="80.0.0" />
+      <PackageReference Include="Remora.Discord.Pagination" Version="5.1.0" />
+      <PackageReference Include="Remora.Rest.Core" Version="3.0.0" />
+      <PackageReference Include="Remora.Results" Version="8.0.0" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+      <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     </ItemGroup>
 

--- a/src/PhishingAPI/Kobalt.Phishing.API/Kobalt.Phishing.API.csproj
+++ b/src/PhishingAPI/Kobalt.Phishing.API/Kobalt.Phishing.API.csproj
@@ -25,7 +25,7 @@
 
     <ItemGroup>
       <PackageReference Include="CoenM.ImageSharp.ImageHash" Version="1.3.6" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
     </ItemGroup>
 
 </Project>

--- a/src/PhishingAPI/Kobalt.Phishing.API/Program.cs
+++ b/src/PhishingAPI/Kobalt.Phishing.API/Program.cs
@@ -14,7 +14,7 @@ using Remora.Rest.Json.Policies;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
-builder.Services.AddSerilogLogging();
+builder.Services.AddSerilogLogging(builder.Configuration);
 
 var configure = (JsonSerializerOptions options) =>
 {

--- a/src/PhishingAPI/Kobalt.Phishing.Data/Kobalt.Phishing.Data.csproj
+++ b/src/PhishingAPI/Kobalt.Phishing.Data/Kobalt.Phishing.Data.csproj
@@ -8,16 +8,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+      <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PhishingAPI/Kobalt.Phishing.Shared/Kobalt.Phishing.Shared.csproj
+++ b/src/PhishingAPI/Kobalt.Phishing.Shared/Kobalt.Phishing.Shared.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Refit" Version="8.0.0" />
-      <PackageReference Include="Remora.Rest.Core" Version="2.2.1" />
+      <PackageReference Include="Remora.Rest.Core" Version="3.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/ReminderAPI/Kobalt.Reminders.API/Kobalt.Reminders.API.csproj
+++ b/src/ReminderAPI/Kobalt.Reminders.API/Kobalt.Reminders.API.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit" Version="8.3.1" />
-        <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.1" />
+        <PackageReference Include="MassTransit" Version="8.5.0" />
+        <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.0" />
 
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ReminderAPI/Kobalt.Reminders.API/Program.cs
+++ b/src/ReminderAPI/Kobalt.Reminders.API/Program.cs
@@ -16,7 +16,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddUserSecrets<Program>();
 
-builder.Services.AddSerilogLogging();
+builder.Services.AddSerilogLogging(builder.Configuration);
 builder.Services.AddMediatR(s => s.RegisterServicesFromAssemblyContaining<ReminderContext>());
 builder.Services.AddDbContextFactory<ReminderContext>("Reminders");
 

--- a/src/ReminderAPI/Kobalt.Reminders.Data/Kobalt.Reminders.Data.csproj
+++ b/src/ReminderAPI/Kobalt.Reminders.Data/Kobalt.Reminders.Data.csproj
@@ -8,17 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+      <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
-      <PackageReference Include="Remora.Results" Version="7.4.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+      <PackageReference Include="Remora.Results" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Kobalt.Bot.Tests/Configuration/ConfigurationLoadingTests.cs
+++ b/tests/Kobalt.Bot.Tests/Configuration/ConfigurationLoadingTests.cs
@@ -1,0 +1,160 @@
+using System.IO;
+using Kobalt.Infrastructure.Types;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework; // Changed from Xunit
+using System.Collections.Generic; // For IReadOnlyList
+
+namespace Kobalt.Bot.Tests.Configuration;
+
+[TestFixture] // Changed from public class
+public class ConfigurationLoadingTests
+{
+    private KobaltConfig LoadTestConfiguration(string jsonConfig)
+    {
+        var memoryStream = new MemoryStream();
+        var writer = new StreamWriter(memoryStream);
+        writer.Write(jsonConfig);
+        writer.Flush();
+        memoryStream.Position = 0;
+
+        var configuration = new ConfigurationBuilder()
+            .AddJsonStream(memoryStream)
+            .Build();
+
+        var services = new ServiceCollection();
+        // Ensure we are binding the "Kobalt" section from the JSON to the KobaltConfig class
+        services.Configure<KobaltConfig>(configuration.GetSection("Kobalt"));
+        var serviceProvider = services.BuildServiceProvider();
+
+        return serviceProvider.GetRequiredService<IOptions<KobaltConfig>>().Value;
+    }
+
+    [Test] // Changed from Fact
+    public void Should_Load_Bot_Activity_Settings_Correctly()
+    {
+        var json = """
+        {
+          "Kobalt": {
+            "Bot": {
+              "DefaultActivityType": "Listening",
+              "DefaultActivityName": "to your commands"
+            }
+          }
+        }
+        """;
+
+        var config = LoadTestConfiguration(json);
+
+        Assert.That(config.Bot, Is.Not.Null);
+        Assert.That(config.Bot.DefaultActivityType, Is.EqualTo("Listening"));
+        Assert.That(config.Bot.DefaultActivityName, Is.EqualTo("to your commands"));
+    }
+
+    [Test] // Changed from Fact
+    public void Should_Load_OwnerIDs_Correctly()
+    {
+        var json = """
+        {
+          "Kobalt": {
+            "Bot": {
+              "OwnerIDs": [ 111222333444555, 666777888999000 ]
+            }
+          }
+        }
+        """;
+
+        var config = LoadTestConfiguration(json);
+
+        Assert.That(config.Bot, Is.Not.Null);
+        Assert.That(config.Bot.OwnerIDs, Is.Not.Null);
+        Assert.That(config.Bot.OwnerIDs.Count, Is.EqualTo(2));
+        CollectionAssert.Contains(config.Bot.OwnerIDs, 111222333444555UL);
+        CollectionAssert.Contains(config.Bot.OwnerIDs, 666777888999000UL);
+    }
+
+    [Test] // Changed from Fact
+    public void Should_Use_Default_Activity_Settings_When_Not_Provided()
+    {
+        var jsonWithDiscord = """
+        {
+          "Kobalt": {
+            "Bot": {
+            },
+            "Discord": {
+              "Token": "TestToken",
+              "ShardCount": 1
+            }
+          }
+        }
+        """;
+
+        var config = LoadTestConfiguration(jsonWithDiscord);
+
+        Assert.That(config.Bot, Is.Not.Null);
+        // Default values from KobaltBotConfig record definition
+        Assert.That(config.Bot.DefaultActivityType, Is.EqualTo("Watching"));
+        Assert.That(config.Bot.DefaultActivityName, Is.EqualTo("Code being written"));
+    }
+
+    [Test] // Changed from Fact
+    public void Should_Handle_Empty_OwnerIDs_When_Not_Provided()
+    {
+        var jsonWithDiscord = """
+        {
+          "Kobalt": {
+            "Bot": {
+            },
+            "Discord": {
+              "Token": "TestToken",
+              "ShardCount": 1
+            }
+          }
+        }
+        """;
+        var config = LoadTestConfiguration(jsonWithDiscord);
+
+        Assert.That(config.Bot, Is.Not.Null);
+        Assert.That(config.Bot.OwnerIDs, Is.Null); // Default value is null from record definition
+    }
+
+    [Test] // Changed from Fact
+    public void Should_Load_Full_Example_Configuration_Segment_Correctly()
+    {
+        var json = """
+        {
+          "Kobalt": {
+            "Bot": {
+              "OwnerIDs": [ 9876543210, 1234567890 ],
+              "DefaultActivityType": "Playing",
+              "DefaultActivityName": "a game",
+              "EnableReminders": false,
+              "InfractionsUrl": "http://localhost:1234"
+            },
+            "Discord": {
+              "Token": "FakeToken",
+              "ShardCount": 2,
+              "PublicKey": "FakeKey"
+            }
+          }
+        }
+        """;
+
+        var config = LoadTestConfiguration(json);
+
+        Assert.That(config.Bot, Is.Not.Null);
+        Assert.That(config.Bot.DefaultActivityType, Is.EqualTo("Playing"));
+        Assert.That(config.Bot.DefaultActivityName, Is.EqualTo("a game"));
+        Assert.That(config.Bot.EnableReminders, Is.False);
+        Assert.That(config.Bot.InfractionsUrl, Is.EqualTo("http://localhost:1234"));
+        Assert.That(config.Bot.OwnerIDs, Is.Not.Null);
+        CollectionAssert.Contains(config.Bot.OwnerIDs, 9876543210UL);
+        CollectionAssert.Contains(config.Bot.OwnerIDs, 1234567890UL);
+
+        Assert.That(config.Discord, Is.Not.Null);
+        Assert.That(config.Discord.Token, Is.EqualTo("FakeToken"));
+        Assert.That(config.Discord.ShardCount, Is.EqualTo(2));
+        Assert.That(config.Discord.PublicKey, Is.EqualTo("FakeKey"));
+    }
+}

--- a/tests/Kobalt.Bot.Tests/Kobalt.Bot.Tests.csproj
+++ b/tests/Kobalt.Bot.Tests/Kobalt.Bot.Tests.csproj
@@ -9,26 +9,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.Abstractions" Version="8.3.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="MassTransit.Abstractions" Version="8.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Remora.Discord.API.Abstractions" Version="82.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Remora.Discord.API.Abstractions" Version="84.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     </ItemGroup>
 
 

--- a/tests/Kobalt.Bot.Tests/Kobalt.Bot.Tests.csproj
+++ b/tests/Kobalt.Bot.Tests/Kobalt.Bot.Tests.csproj
@@ -23,6 +23,12 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Remora.Discord.API.Abstractions" Version="82.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     </ItemGroup>
 
 

--- a/tests/Kobalt.Infractions.API.Tests/Kobalt.Infractions.API.Tests.csproj
+++ b/tests/Kobalt.Infractions.API.Tests/Kobalt.Infractions.API.Tests.csproj
@@ -12,16 +12,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.TestFramework" Version="8.3.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="MassTransit.TestFramework" Version="8.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Kobalt.Infractions.Data.Tests/Kobalt.Infractions.Data.Tests.csproj
+++ b/tests/Kobalt.Infractions.Data.Tests/Kobalt.Infractions.Data.Tests.csproj
@@ -9,21 +9,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Respawn" Version="6.2.1" />
-        <PackageReference Include="Testcontainers" Version="4.0.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0" />
+        <PackageReference Include="Testcontainers" Version="4.6.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds new configuration options to Kobalt.Bot:
- OwnerIDs: A list of Discord User IDs for bot owners.
- DefaultActivityType: The type of activity for the bot's presence.
- DefaultActivityName: The name of the activity for the bot's presence.

Enables Serilog configuration via `appsettings.json` by updating the shared logging extension to use `ReadFrom.Configuration()`.

Includes:
- Updates to `KobaltConfig.cs` to include the new settings.
- Modifications in `Kobalt.Bot/Program.cs` to use these settings.
- Adjustments in all API `Program.cs` files and `Kobalt.Shared` to support the new Serilog configuration method.
- New NUnit tests for configuration loading in `Kobalt.Bot.Tests`.
- Updated `README.md` with the new configuration options and a more detailed example of `appsettings.json`, including Serilog setup.